### PR TITLE
Refactor(i18n): Add linter suppression about non-exhaustive dependency array of use effect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "sharp": "^0.32.6"
       },
       "devDependencies": {
-        "@types/joi": "^17.2.3",
         "@types/node": "20.8.0",
         "@types/react": "18.2.24",
         "@types/react-dom": "18.2.8",
@@ -984,16 +983,6 @@
       "dependencies": {
         "@types/react": "*",
         "hoist-non-react-statics": "^3.3.0"
-      }
-    },
-    "node_modules/@types/joi": {
-      "version": "17.2.3",
-      "resolved": "https://registry.npmjs.org/@types/joi/-/joi-17.2.3.tgz",
-      "integrity": "sha512-dGjs/lhrWOa+eO0HwgxCSnDm5eMGCsXuvLglMghJq32F6q5LyyNuXb41DHzrg501CKNOSSAHmfB7FDGeUnDmzw==",
-      "deprecated": "This is a stub types definition. joi provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "joi": "*"
       }
     },
     "node_modules/@types/json5": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "sharp": "^0.32.6"
   },
   "devDependencies": {
-    "@types/joi": "^17.2.3",
     "@types/node": "20.8.0",
     "@types/react": "18.2.24",
     "@types/react-dom": "18.2.8",

--- a/src/app/i18n/i18next.ts
+++ b/src/app/i18n/i18next.ts
@@ -50,6 +50,7 @@ export function useTranslation(namespace: string = DefaultNS) {
   useEffect(() => {
     if (cookies.Language && Languages.includes(cookies.Language))
       i18n.changeLanguage(cookies.Language);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const [activeLanguage, setActivelanguage] = useState(i18n.resolvedLanguage);


### PR DESCRIPTION
This non-exhaustive dependency array is used to run this `useEffect` only once, so that the cookies will be evaluated at the beginning.